### PR TITLE
Add additional supported architectures

### DIFF
--- a/.github/workflows/docker-build-deploy.yml
+++ b/.github/workflows/docker-build-deploy.yml
@@ -9,6 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Login to Docker Hub
       uses: docker/login-action@v2
       with:
@@ -19,3 +23,4 @@ jobs:
       with:
         push: true
         tags: slashbunny/humble-vault-downloader:latest
+        platforms: linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/s390x


### PR DESCRIPTION
Hello,

Wanted native arm64 support without having to pull and build the container myself each time.

Tested build with buildx locally. Though I was not able to verify/test the updated github workflow personally, from what I can see in the [documentation](https://docs.docker.com/build/ci/github-actions/multi-platform/), (other than a few version mismatches) this is how it can be done.

I primarily just needed the arm64 support to not have to run this container through a compatibility layer. The other architectures I threw in since they seemed to work and didn't throw any errors in the build process. Doing this many arches on one runner could slow things down a little, but since there isn't any actual compilation happening any slowdown should be minimal.

~Robert